### PR TITLE
beginner_tutorials: 1.0.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1065,6 +1065,22 @@ repositories:
       url: https://github.com/AutonomyLab/bebop_autonomy.git
       version: indigo-devel
     status: developed
+  beginner_tutorials:
+    doc:
+      type: git
+      url: https://github.com/lozeki/beginner_tutorials.git
+      version: auto
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lozeki/beginner_tutorials-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/lozeki/beginner_tutorials.git
+      version: auto
+    status: end-of-life
+    status_description: end-of-life
   behaviortree_cpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `beginner_tutorials` to `1.0.0-1`:

- upstream repository: https://github.com/lozeki/beginner_tutorials.git
- release repository: https://github.com/lozeki/beginner_tutorials-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
