### PR TITLE
catkin: 0.8.12-1 in 'noetic/gitlab_distribution.yaml' [bloom]

### DIFF
--- a/noetic/gitlab_distribution.yaml
+++ b/noetic/gitlab_distribution.yaml
@@ -15,7 +15,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: http://gitlab.halo.dekaresearch.com/kiwi/device/build/ros/catkin-release.git
-      version: 0.8.10-1
+      version: 0.8.12-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.8.12-1`:

- upstream repository: http://gitlab.halo.dekaresearch.com/kiwi/device/build/ros/catkin.git
- release repository: http://gitlab.halo.dekaresearch.com/kiwi/device/build/ros/catkin-release.git
- distro file: `noetic/gitlab_distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.8.10-1`
